### PR TITLE
Remove package-lock.json from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
-package-lock.json
 
 # testing
 /coverage


### PR DESCRIPTION
package-lock.json is required for npm functionality, it should not be git ignored